### PR TITLE
Fix Windows tests from git-archive tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure MSVC CI tests with the same line endings that are used in the tarball
+/tests/baseline_*.txt		eol=lf

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -13,6 +13,10 @@ respectively).
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
 #include "../ini.h"
 
 int User;
@@ -62,6 +66,9 @@ void parse(const char* fname) {
 
 int main(void)
 {
+#ifdef _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     parse("no_file.ini");
     parse("normal.ini");
     parse("bad_section.ini");

--- a/tests/unittest_alloc.c
+++ b/tests/unittest_alloc.c
@@ -3,6 +3,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
 #include "../ini.h"
 
 void* ini_malloc(size_t size) {
@@ -44,6 +48,9 @@ void parse(const char* name, const char* string) {
 
 int main(void)
 {
+#ifdef _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     parse("basic", "[section]\nfoo = bar\nbazz = buzz quxx");
     return 0;
 }

--- a/tests/unittest_string.c
+++ b/tests/unittest_string.c
@@ -3,6 +3,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
 #include "../ini.h"
 
 int User;
@@ -33,6 +37,9 @@ void parse(const char* name, const char* string) {
 
 int main(void)
 {
+#ifdef _WIN32
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
     parse("empty string", "");
     parse("basic", "[section]\nfoo = bar\nbazz = buzz quxx");
     parse("crlf", "[section]\r\nhello = world\r\nforty_two = 42\r\n");


### PR DESCRIPTION
`diff` fails when run from a tarball: the `unittest` programs produce CRLF line endings and `baseline_*.txt` in the tarball uses LF.  Reproduce this in CI by preventing Git from converting the text files to CRLF, then ensure the `unittest` programs produce Unix line endings.